### PR TITLE
Fix Invoicing ssn reading from request

### DIFF
--- a/Model/Method/Financing.php
+++ b/Model/Method/Financing.php
@@ -4,6 +4,7 @@ namespace PayEx\Payments\Model\Method;
 
 use Magento\Framework\DataObject;
 use \Magento\Framework\Exception\LocalizedException;
+use Magento\Quote\Api\Data\PaymentInterface;
 
 /**
  * Class Financing
@@ -121,9 +122,15 @@ class Financing extends \PayEx\Payments\Model\Method\AbstractMethod
             $data = new \Magento\Framework\DataObject($data);
         }
 
+        $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
+        if (!is_object($additionalData)) {
+            $additionalData = new DataObject($additionalData ?: []);
+        }
+
         /** @var \Magento\Quote\Model\Quote\Payment $info */
         $info = $this->getInfoInstance();
-        $info->setSocialSecurityNumber($data->getSocialSecurityNumber());
+        $info->setSocialSecurityNumber($additionalData->getSocialSecurityNumber());
+
         return $this;
     }
 


### PR DESCRIPTION
Method validation failed because of incorrectly assigned social security number when using Financing and PartPayment.
In web/js/view/payment/method-renderer/payex-financing-memthod.js social_security_number is sent as part of additional_data, but payment method assignData() reads incoming values from outside additional_data, which is empty, so validation fails.