### PR TITLE
Fix guest cart management plugin to use correct quote model

### DIFF
--- a/Model/Checkout/GuestPaymentInformationManagement/Plugin.php
+++ b/Model/Checkout/GuestPaymentInformationManagement/Plugin.php
@@ -12,17 +12,17 @@ class Plugin
     protected $session;
 
     /**
-     * @var \Magento\Quote\Api\CartManagementInterface
+     * @var \Magento\Quote\Api\GuestCartManagementInterface
      */
     protected $cartManagement;
 
     /**
      * @param \Magento\Checkout\Model\Session $session
-     * @param \Magento\Quote\Api\CartManagementInterface $cartManagement
+     * @param \Magento\Quote\Api\GuestCartManagementInterface $cartManagement
      */
     public function __construct(
         \Magento\Checkout\Model\Session $session,
-        \Magento\Quote\Api\CartManagementInterface $cartManagement
+        \Magento\Quote\Api\GuestCartManagementInterface $cartManagement
     )
     {
         $this->session = $session;


### PR DESCRIPTION
Using customer quote management instead of guest quote managemend results in quote not found error when placing error.

As a side note, how about removing aroundSavePaymentInformationAndPlaceOrder override in this plugin? The only thing it does is wrap exception message, with a cost of completely replacing core implementation, this might seem too risky.

Thanks for review, looking forward to your reply (and merge :)