### PR TITLE
[EPLECARE-120] Fix identifying order

### DIFF
--- a/Controller/Cc/Success.php
+++ b/Controller/Cc/Success.php
@@ -81,7 +81,7 @@ class Success extends \Magento\Framework\App\Action\Action
         }
 
         // Load Order
-        $order = $this->getOrder();
+        $order = $this->getOrder($orderRef);
         if (!$order->getId()) {
             $this->session->restoreQuote();
             $this->messageManager->addError(__('No order for processing found'));
@@ -256,22 +256,19 @@ class Success extends \Magento\Framework\App\Action\Action
     }
 
     /**
-     * Get order object
+     * Get order object by external reference saved in payment
+     * @param string $orderRef
      * @return \Magento\Sales\Model\Order
      */
-    protected function getOrder()
+    protected function getOrder($orderRef)
     {
-        $incrementId = $this->getCheckout()->getLastRealOrderId();
-        $orderFactory = $this->_objectManager->get('Magento\Sales\Model\OrderFactory');
-        return $orderFactory->create()->loadByIncrementId($incrementId);
-    }
-
-    /**
-     * Get Checkout Session
-     * @return \Magento\Checkout\Model\Session
-     */
-    protected function getCheckout()
-    {
-        return $this->_objectManager->get('Magento\Checkout\Model\Session');
+        $searchCriteriaBuilder = $this->_objectManager->create('Magento\Framework\Api\SearchCriteriaBuilder');
+        $searchCriteria = $searchCriteriaBuilder->addFilter(
+            'po_number',
+            $orderRef,
+            'eq'
+        )->create();
+        $payment = $this->_objectManager->get('Magento\Sales\Model\Order\Payment\Repository')->getList($searchCriteria)->getFirstItem();
+        return $payment->getOrder();
     }
 }

--- a/Model/Method/Cc.php
+++ b/Model/Method/Cc.php
@@ -245,6 +245,8 @@ class Cc extends \PayEx\Payments\Model\Method\AbstractMethod
             $this->payexLogger->info('PxOrder.AddOrderAddress2', $result);
         }
 
+        // Save order reference in payment
+        $order->getPayment()->setPoNumber($order_ref);
         // Set Pending Payment status
         $order->addStatusHistoryComment(__('The customer was redirected to PayEx.'), \Magento\Sales\Model\Order::STATE_PENDING_PAYMENT);
         $order->save();


### PR DESCRIPTION
There was a bug when customers making several orders - opens multiple Payex pages and after paying in older ones payment(transaction) is always assigned to the latest order.